### PR TITLE
Refactor

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -8,6 +8,13 @@
   .topic-list .views {
     display: none;
   }
+  .topic-list-bottom {
+    #dismiss-topics,
+    #dismiss-new,
+    .footer-message {
+      display: none;
+    }
+  }
   .kb-search {
     align-items: center;
     background-color: $primary-very-low;

--- a/javascripts/discourse/components/knowledge-base-search-results.js.es6
+++ b/javascripts/discourse/components/knowledge-base-search-results.js.es6
@@ -2,15 +2,14 @@ import computed from "ember-addons/ember-computed-decorators";
 
 export default Ember.Component.extend({
   classNames: "kb-search-results",
-  kbHelper: Ember.inject.service(),
 
-  @computed("filteredList")
-  count(filteredList) {
-    return filteredList.length;
+  @computed("searchResults")
+  count(results) {
+    return results.length;
   },
 
-  @computed("filteredList")
-  empty(filteredList){
-    return filteredList === "empty";
+  @computed("searchResults")
+  empty(results){
+    return !results || results.length === 0;
   }
 });

--- a/javascripts/discourse/components/knowledge-base-tag.js.es6
+++ b/javascripts/discourse/components/knowledge-base-tag.js.es6
@@ -1,16 +1,14 @@
 import computed from "ember-addons/ember-computed-decorators";
 import DiscourseURL from "discourse/lib/url";
+import { hrefForTag } from "discourse/components/knowledge-base";
 
 export default Ember.Component.extend({
-  kbHelper: Ember.inject.service(),
-
   @computed("category", "tag")
   href(category, tag) {
-    return this.kbHelper.hrefForTag(category, tag.id);
+    return hrefForTag(category, tag.id);
   },
 
-  click(event) {
-    this.set("filteredList", null);
+  click() {
     DiscourseURL.routeTo(this.href, { replaceURL: true });
   }
 });

--- a/javascripts/discourse/components/knowledge-base.js.es6
+++ b/javascripts/discourse/components/knowledge-base.js.es6
@@ -1,0 +1,99 @@
+import knowledgeBase from 'discourse/models/knowledge-base';
+import { default as computed, observes, on } from "ember-addons/ember-computed-decorators";
+import debounce from "discourse/lib/debounce";
+
+function arrayContainsArray(superset, subset) {
+  if (0 === subset.length) {
+    return false;
+  }
+  return subset.every(v => superset.indexOf(v) >= 0);
+}
+
+export default Ember.Component.extend({
+  searchTerm: null,
+  searchResults: null,
+
+  @on("didReceiveAttrs")
+  update() {
+    if (this.active) {
+      document.body.classList.add("kb-active");
+      Ember.run.later(() => {
+        this.filterTopicsList();
+      });
+    } else {
+      document.body.classList.remove("kb-active");
+    }
+  },
+
+  filterTopicsList() {
+    const model = this.model;
+    let tagsFilter = kbParams();
+
+    if (tagsFilter) {
+      tagsFilter = tagsFilter.split(" ");
+      model.set("topics", model.topics.filter(topic => arrayContainsArray(topic.tags, tagsFilter)));
+    }
+  },
+
+  @computed("category")
+  active(category) {
+    const kbCategories = settings.kb_categories.split("|").filter(n => n);
+    const tagsEnabled = this.siteSettings.tagging_enabled;
+    const tagFilterEnabled = this.siteSettings.show_filter_by_tag;
+    const enabledForCategory = category && kbCategories.includes(category.slug)
+
+    if (kbCategories.length === 0) {
+      return false;
+    }
+    if (!tagsEnabled || !tagFilterEnabled) {
+      console.warn("Knowledge Base Theme Component requires the following site settings to be enabled: `tagging_enabled` and `show_filter_by_tag`");
+      return false;
+    }
+    return enabledForCategory
+  },
+
+  @computed("searchResults")
+  hasSearchResults(results) {
+    return !!results;
+  }
+});
+
+export function kbParams() {
+  const params = window.location.search;
+  if (params) {
+    const match = params.match(/tags=([^&]*)/);
+    if (match) {
+      return decodeURIComponent(match[1]);
+    }
+  }
+}
+
+export function hrefForTag(category, tagName) {
+  let destinationURL = "";
+  if (category && tagName) {
+    const slug = Discourse.Category.slugFor(category);
+    let tagsParam = kbParams();
+
+    if (tagsParam) { //if existing params
+      if (tagsParam.includes(tagName)) { // removing a param
+
+        tagsParam = tagsParam.replace(tagName, '');
+        tagsParam = tagsParam.replace(/^\s+|\s+$/g, '');
+
+        if (tagsParam === "") { // if no params, send base category URL
+          destinationURL = `/c/${slug}?tags=`;
+        }
+        else {
+          destinationURL = `/c/${slug}?tags=${tagsParam}`; // send URL with removed params
+        }
+      }
+      else { //if adding new param
+        destinationURL = `/c/${slug}?tags=${tagsParam} ${tagName}`; 
+      }
+    }
+    else { //if no existing params
+      destinationURL = `/c/${slug}?tags=${tagName}`;
+    }
+  }
+  return destinationURL;
+}

--- a/javascripts/discourse/initializers/kb-setup.js.es6
+++ b/javascripts/discourse/initializers/kb-setup.js.es6
@@ -1,13 +1,6 @@
 import { default as computed, on, observes } from "ember-addons/ember-computed-decorators";
 import { withPluginApi } from "discourse/lib/plugin-api";
 
-function arrayContainsArray(superset, subset) {
-  if (0 === subset.length) {
-    return false;
-  }
-  return subset.every(v => superset.indexOf(v) >= 0);
-}
-
 export default {
   name: "kb-setup",
   initialize() {
@@ -21,106 +14,8 @@ export default {
         }
         else {
           document.body.classList.remove("kb-active");
-	}
+        }
       });
-
-      api.modifyClass("controller:discovery/topics", {
-        kbHelper: Ember.inject.service(),
-        filteredList: null,
-
-        @on("init")
-        @observes("category")
-        kbChangeCategory() {
-          this.kbHelper.updateCurrentCategory(this.category);
-        },
-
-        @computed("kbHelper.active")
-        kbActive(active) {
-          return active;
-        },
-
-        @observes("model")
-        kbFilterTopics(){
-          if (this.kbActive) {
-            const model = this.get("model");
-            let tagsFilter = this.kbHelper.kbParams();
-            if (tagsFilter) {
-              tagsFilter = tagsFilter.split(" ");
-              model.topics = model.topics.filter(topic => {
-               let tags = topic.tags;
-
-               return arrayContainsArray(tags, tagsFilter);
-              });
-              this.set("model", model);
-            }
-          }
-        },
-      });
-
-      Discourse.register("service:kb-helper", Ember.Service.extend({
-        updateCurrentCategory(category) {
-          this.set("discoveryCategory", category);
-        },
-
-        hrefForTag(category, tagName) {
-          let destinationURL = "";
-          if (category && tagName) {
-            const slug = Discourse.Category.slugFor(category);
-            let tagsParam = this.kbParams();
-
-            if (tagsParam) { //if existing params
-              if (tagsParam.includes(tagName)) { // removing a param
-
-                tagsParam = tagsParam.replace(tagName, '');
-                tagsParam = tagsParam.replace(/^\s+|\s+$/g, '');
-
-                if (tagsParam === "") { // if no params, send base category URL
-                  destinationURL = `/c/${slug}?tags=`;
-                }
-                else {
-                  destinationURL = `/c/${slug}?tags=${tagsParam}`; // send URL with removed params
-                }
-              }
-              else { //if adding new param
-                destinationURL = `/c/${slug}?tags=${tagsParam} ${tagName}`; 
-              }
-            }
-            else { //if no existing params
-              destinationURL = `/c/${slug}?tags=${tagName}`;
-            }
-          }
-          return destinationURL;
-        },
-
-        kbParams(){
-          const params = window.location.search;
-          if (params) {
-            const match = params.match(/tags=([^&]*)/);
-            if (match) {
-              return decodeURIComponent(match[1]);
-            }
-          }
-        },
-
-        @computed("discoveryCategory")
-        active(category) {
-          const siteSettings = api.container.lookup("site-settings:main");
-          const kbCategories = settings.kb_categories.split("|").filter(n => n);
-          const tagsEnabled = siteSettings.tagging_enabled;
-          const tagFilterEnabled = siteSettings.show_filter_by_tag;
-          const enabledForCategory = category && kbCategories.includes(category.slug)
-
-          if (kbCategories.length === 0) {
-            return false;
-          }
-          if (!tagsEnabled || !tagFilterEnabled) {
-            console.log("Knowledge Base Theme Component requires the following site settings to be enabled: `tagging_enabled` and `show_filter_by_tag`");
-            return false;
-          }
-          return enabledForCategory
-        },
-
-      }));
     });
   }
 }

--- a/javascripts/discourse/models/knowledge-base.js.es6
+++ b/javascripts/discourse/models/knowledge-base.js.es6
@@ -1,14 +1,12 @@
 import { ajax } from 'discourse/lib/ajax';
 
 export default {
-    
-    findKBFromCategory(category, tags, filter) {
-      if (tags) {
-        return ajax(`/search.json?q=%23${category.slug} tags:${tags.replace(/ /g, "+")} ${filter}`);
-      }
-      else {
-        return ajax(`/search.json?q=%23${category.slug} ${filter}`);
-      }
+  findKBFromCategory(category, tags, filter) {
+    if (tags) {
+      return ajax(`/search.json?q=%23${category.slug} tags:${tags.replace(/ /g, "+")} ${filter}`);
     }
-
+    else {
+      return ajax(`/search.json?q=%23${category.slug} ${filter}`);
+    }
+  }
 };

--- a/javascripts/discourse/templates/components/knowledge-base-search-results.hbs
+++ b/javascripts/discourse/templates/components/knowledge-base-search-results.hbs
@@ -7,7 +7,7 @@
       <th>Topic</th>
     </thead>
     <tbody>
-      {{#each filteredList as |item|}}
+      {{#each searchResults as |item|}}
         <tr>
           <td class="main-link">
             <span class="link-top-line">

--- a/javascripts/discourse/templates/components/knowledge-base-search.hbs
+++ b/javascripts/discourse/templates/components/knowledge-base-search.hbs
@@ -1,1 +1,8 @@
-{{text-field value=filter class="kb-search-bar" placeholderKey=(theme-prefix "kb.search.placeholder") autocorrect="off" autocapitalize="off"}}
+<input
+  type="text"
+  value={{searchTerm}}
+  oninput={{action "onSearchTermChange"}}
+  class="kb-search-bar"
+  placeholder={{theme-i18n 'kb.search.placeholder'}}
+  autocorrect="off"
+  autocapitalize="off">

--- a/javascripts/discourse/templates/components/knowledge-base-tags.hbs
+++ b/javascripts/discourse/templates/components/knowledge-base-tags.hbs
@@ -2,11 +2,19 @@
 </a></h3>
 
 {{#each tags as |tag|}}
-    {{knowledge-base-tag tag=tag category=category activeTagSelection=activeTagSelection filteredList=filteredList}}
+    {{knowledge-base-tag
+      tag=tag category=category
+      activeTagSelection=activeTagSelection
+      resetSearchResults=resetSearchResults}}
 {{/each}}
 
 {{#if subtags}}
    {{#each subtags as |tag|}}
-     {{knowledge-base-tag tag=tag category=category activeTagSelection=activeTagSelection filteredList=filteredList subtag=true}}
+     {{knowledge-base-tag
+       tag=tag
+       category=category
+       activeTagSelection=activeTagSelection
+       resetSearchResults=resetSearchResults
+       subtag=true}}
    {{/each}}
 {{/if}}

--- a/javascripts/discourse/templates/components/knowledge-base.hbs
+++ b/javascripts/discourse/templates/components/knowledge-base.hbs
@@ -1,0 +1,16 @@
+{{#if active}}
+  {{knowledge-base-search category=category searchResults=searchResults searchTerm=searchTerm}}
+  <div class="kb-area">
+    {{knowledge-base-tags
+      category=category
+      model=model
+      searchResults=searchResults}}
+    {{#if hasSearchResults}}
+      {{knowledge-base-search-results searchResults=searchResults}}
+    {{else}}
+      {{yield true}}
+    {{/if}}
+  </div>
+{{else}}
+  {{yield false}}
+{{/if}}

--- a/javascripts/discourse/templates/discovery/topics.hbs
+++ b/javascripts/discourse/templates/discovery/topics.hbs
@@ -25,58 +25,7 @@
 {{/if}}
 
 {{bulk-select-button selected=selected action=(action "refresh") category=category}}
-{{#if kbActive}}
-  {{knowledge-base-search category=category filteredList=filteredList}}
-  <div class="kb-area">
-  {{knowledge-base-tags category=category topics=model.topics filteredList=filteredList}}
-  {{#if filteredList}}
-    {{knowledge-base-search-results filteredList=filteredList}}
-  {{else}}
-    {{#discovery-topics-list model=model refresh=(action "refresh") incomingCount=topicTrackingState.incomingCount}}
-      {{#if top}}
-        <div class='top-lists'>
-          {{period-chooser period=period action=(action "changePeriod")}}
-        </div>
-      {{else}}
-        {{#if topicTrackingState.hasIncoming}}
-          <div class="show-more {{if hasTopics 'has-topics'}}">
-            <div class='alert alert-info clickable' {{action "showInserted"}}>
-              <a tabindex="0" href="" {{action "showInserted"}}>
-                {{count-i18n key="topic_count_" suffix=topicTrackingState.filter count=topicTrackingState.incomingCount}}
-              </a>
-            </div>
-          </div>
-        {{/if}}
-      {{/if}}
-
-      {{#if hasTopics}}
-        {{topic-list
-          kbActive=kbActive
-          highlightLastVisited=true
-          top=top
-          showTopicPostBadges=showTopicPostBadges
-          showPosters=false
-          canBulkSelect=canBulkSelect
-          changeSort=(action "changeSort")
-          toggleBulkSelect=(action "toggleBulkSelect")
-          hideCategory=model.hideCategory
-          order=order
-          ascending=ascending
-          bulkSelectEnabled=bulkSelectEnabled
-          selected=selected
-          expandGloballyPinned=expandGloballyPinned
-          expandAllPinned=expandAllPinned
-          category=category
-          topics=model.topics
-          discoveryList=true}}
-      {{/if}}
-    {{/discovery-topics-list}}
-  {{/if}}
-  </div>
-  <footer class='topic-list-bottom'>
-    {{conditional-loading-spinner condition=model.loadingMore}}
-  </footer>
-{{else}}
+{{#knowledge-base category=category model=model as |kbActive|}}
   {{#discovery-topics-list model=model refresh=(action "refresh") incomingCount=topicTrackingState.incomingCount}}
     {{#if top}}
       <div class='top-lists'>
@@ -99,7 +48,7 @@
         highlightLastVisited=true
         top=top
         showTopicPostBadges=showTopicPostBadges
-        showPosters=true
+        showPosters=(if kbActive false true)
         canBulkSelect=canBulkSelect
         changeSort=(action "changeSort")
         toggleBulkSelect=(action "toggleBulkSelect")
@@ -115,29 +64,29 @@
         discoveryList=true}}
     {{/if}}
   {{/discovery-topics-list}}
-  <footer class='topic-list-bottom'>
-    {{conditional-loading-spinner condition=model.loadingMore}}
-    {{#if allLoaded}}
-      {{#if showDismissRead}}
-        <button title="{{i18n 'topics.bulk.dismiss_tooltip'}}" id='dismiss-topics' class='btn btn-default dismiss-read' {{action "dismissReadPosts"}}>{{i18n 'topics.bulk.dismiss_button'}}</button>
-      {{/if}}
-      {{#if showResetNew}}
-        <button id='dismiss-new' class='btn btn-default dismiss-read' {{action "resetNew"}}>
-          {{d-icon "check"}} {{i18n 'topics.bulk.dismiss_new'}}</button>
-      {{/if}}
+{{/knowledge-base}}
 
-      {{#footer-message education=footerEducation message=footerMessage}}
-        {{#if latest}}
-          {{#if canCreateTopicOnCategory}}<a href {{action "createTopic"}}>{{i18n 'topic.suggest_create_topic'}}</a>{{/if}}
-        {{else if top}}
-          {{#link-to "discovery.categories"}}{{i18n 'topic.browse_all_categories'}}{{/link-to}}, {{#link-to 'discovery.latest'}}{{i18n 'topic.view_latest_topics'}}{{/link-to}} {{i18n 'or'}} {{i18n 'filters.top.other_periods'}}
-          {{top-period-buttons period=period action=(action "changePeriod")}}
-        {{else}}
-          {{#link-to "discovery.categories"}} {{i18n 'topic.browse_all_categories'}}{{/link-to}} {{i18n 'or'}} {{#link-to 'discovery.latest'}}{{i18n 'topic.view_latest_topics'}}{{/link-to}}
-        {{/if}}
-      {{/footer-message}}
-
+<footer class='topic-list-bottom'>
+  {{conditional-loading-spinner condition=model.loadingMore}}
+  {{#if allLoaded}}
+    {{#if showDismissRead}}
+      <button title="{{i18n 'topics.bulk.dismiss_tooltip'}}" id='dismiss-topics' class='btn btn-default dismiss-read' {{action "dismissReadPosts"}}>{{i18n 'topics.bulk.dismiss_button'}}</button>
     {{/if}}
-  </footer>
-{{/if}}
+    {{#if showResetNew}}
+      <button id='dismiss-new' class='btn btn-default dismiss-read' {{action "resetNew"}}>
+        {{d-icon "check"}} {{i18n 'topics.bulk.dismiss_new'}}</button>
+    {{/if}}
 
+    {{#footer-message education=footerEducation message=footerMessage}}
+      {{#if latest}}
+        {{#if canCreateTopicOnCategory}}<a href {{action "createTopic"}}>{{i18n 'topic.suggest_create_topic'}}</a>{{/if}}
+      {{else if top}}
+        {{#link-to "discovery.categories"}}{{i18n 'topic.browse_all_categories'}}{{/link-to}}, {{#link-to 'discovery.latest'}}{{i18n 'topic.view_latest_topics'}}{{/link-to}} {{i18n 'or'}} {{i18n 'filters.top.other_periods'}}
+        {{top-period-buttons period=period action=(action "changePeriod")}}
+      {{else}}
+        {{#link-to "discovery.categories"}} {{i18n 'topic.browse_all_categories'}}{{/link-to}} {{i18n 'or'}} {{#link-to 'discovery.latest'}}{{i18n 'topic.view_latest_topics'}}{{/link-to}}
+      {{/if}}
+    {{/footer-message}}
+
+  {{/if}}
+</footer>


### PR DESCRIPTION
Ok @justindirose this is what I had in mind for entirely avoiding modifying `controller:discovery/topics`, and reducing the duplication in `discovery/topics.hbs` (if you ignore indentation changes, there are only 2 lines added, and 1 line changed).

The essence of this change is the new `knowledge-base` component. This component now holds all of the methods/attributes we were monkey-patching into `controller:discovery/topics`, and in `topics.hbs` the new component wraps the code that we want to reuse, which we then can `{{yield}}` at any place we want in the wrapper component i.e. `knowledge-base`.

What do you think? If you have any questions let me know!

P.S. I think we should run Prettier here so it automatically tidies the code up for us.