### PR TITLE
DEV: Add maximum version metadata and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# discourse-knowledge-base-theme
+
+DEPRECATED. This theme component has been replaced with http://github.com/discourse/discourse-docs

--- a/about.json
+++ b/about.json
@@ -6,7 +6,7 @@
   "authors": "Justin DiRose",
   "theme_version": "0.1",
   "minimum_discourse_version": null,
-  "maximum_discourse_version": null,
+  "maximum_discourse_version": "2.6.0",
   "assets": {
   },
   "color_schemes": {


### PR DESCRIPTION
This will make the component auto-disable itself on Discourse versions greater than or equal to v2.7.0.beta1

This component has been replaced with the discourse-docs plugin: http://github.com/discourse/discourse-docs